### PR TITLE
extra slash on usb pass-thru

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ services:
     container_name: readsb
     restart: always
     devices:
-      - /dev/bus/usb:/dev/bus/usb/
+      - /dev/bus/usb:/dev/bus/usb
     ports:
       - 8080:8080
       - 30005:30005


### PR DESCRIPTION
extra slash at the end of the usb pass-thru line in the docker-compose example

I have write privileges in here but I still wanted to route this edit through you like the others I've sent recently